### PR TITLE
Fixed xway script: replaced kwayland-server dependency with kwin as kwayland-server got merged into kwin

### DIFF
--- a/usr/local/bin/data/xway
+++ b/usr/local/bin/data/xway
@@ -4,7 +4,7 @@ echo "#################################"
 echo " Adding/Enabling Wayland Support "
 echo "#################################"
 sleep 3
-sudo pacman -S --noconfirm --needed egl-wayland xorg-xwayland kwayland-server kwayland-integration plasma-wayland-session plasma-wayland-protocols qt6-wayland
+sudo pacman -S --noconfirm --needed egl-wayland xorg-xwayland kwin kwayland-integration plasma-wayland-session plasma-wayland-protocols qt6-wayland
 sleep 3
 echo "#################################"
 echo "      Done! Will Reboot Now      "


### PR DESCRIPTION
kwayland-server got merged into kwin and is not avaliable in the repositories anymore. I changed the xway script so that it doesn't check for kwayland-server but for kwin instead.